### PR TITLE
Authorization header

### DIFF
--- a/lib/api_auth.ex
+++ b/lib/api_auth.ex
@@ -1,18 +1,69 @@
 defmodule ApiAuth do
   @moduledoc """
-  Documentation for ApiAuth.
+  This is the ApiAuth module.
+
+  It provides an HMAC authentication system for APIs.
   """
 
+  alias Calendar.DateTime, as: DateTime
+
   @doc """
-  Hello world.
+  Generates an Authorization header
+
+  Returns the string "ApiAuth client_id:<signature>"
 
   ## Examples
 
-      iex> ApiAuth.hello
-      :world
+      iex> ApiAuth.authorization("/foo", "id", "secret", method: "GET",
+      ...>                       time: "Sat, 01 Jan 2000 00:00:00 GMT" |> Calendar.DateTime.Parse.httpdate!)
+      "APIAuth id:Uv9YsGct6RFBFDxn5NhUPGqe+EVRQXrE5QLjVWXkga8="
 
   """
-  def hello do
-    :world
+  def authorization(uri, client_id, secret_key, opts \\ []) do
+    method         = opts |> Keyword.get(:method, "GET")
+    content_type   = opts |> Keyword.get(:content_type, "")
+    content        = opts |> Keyword.get(:content, "")
+    content_hash   = opts |> Keyword.get(:content_hash, :sha256)
+    hashed_content = opts |> Keyword.get(:hashed_content, hashed(content, content_hash))
+    time           = opts |> Keyword.get(:time, DateTime.now_utc)
+    separator      = opts |> Keyword.get(:separator, ",")
+    signature_hash = opts |> Keyword.get(:signature_hash, :sha256)
+
+    string = canonical_string(
+      String.upcase(method),
+      content_type,
+      hashed_content,
+      uri,
+      timestamp(time),
+      separator
+    )
+
+    string
+    |> signature(secret_key, signature_hash)
+    |> header(client_id)
+  end
+
+  defp header(signature, client_id) do
+    "APIAuth #{client_id}:#{signature}"
+  end
+
+  defp timestamp(time) do
+    time
+    |> DateTime.Format.httpdate
+  end
+
+  defp hashed(content, hash) do
+    :crypto.hash(hash, content)
+    |> Base.encode64()
+  end
+
+  defp canonical_string(method, content_type, hashed_content, request_uri, timestamp, separator) do
+    [method, content_type, hashed_content, request_uri, timestamp]
+    |> Enum.join(separator)
+  end
+
+  defp signature(canonical_string, secret_key, hash) do
+    :crypto.hmac(hash, secret_key, canonical_string)
+    |> Base.encode64()
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -7,22 +7,19 @@ defmodule ApiAuth.Mixfile do
       version: "0.1.0",
       elixir: "~> 1.5",
       start_permanent: Mix.env == :prod,
-      deps: deps()
+      deps: deps(),
     ]
   end
 
-  # Run "mix help compile.app" to learn about applications.
   def application do
     [
       extra_applications: [:logger]
     ]
   end
 
-  # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      # {:dep_from_hexpm, "~> 0.3.0"},
-      # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"},
+      {:calendar, "~> 0.17"},
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,9 @@
+%{"calendar": {:hex, :calendar, "0.17.3", "eb5db3142cb808ce1d6d604e61d50e50bc0576da03cb9202b0993e97e8045d37", [:mix], [{:tzdata, "~> 0.5.8 or ~> 0.1.201603", [hex: :tzdata, repo: "hexpm", optional: false]}], "hexpm"},
+  "certifi": {:hex, :certifi, "2.0.0", "a0c0e475107135f76b8c1d5bc7efb33cd3815cb3cf3dea7aefdd174dabead064", [], [], "hexpm"},
+  "hackney": {:hex, :hackney, "1.9.0", "51c506afc0a365868469dcfc79a9d0b94d896ec741cfd5bd338f49a5ec515bfe", [], [{:certifi, "2.0.0", [hex: :certifi, repo: "hexpm", optional: false]}, {:idna, "5.1.0", [hex: :idna, repo: "hexpm", optional: false]}, {:metrics, "1.0.1", [hex: :metrics, repo: "hexpm", optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, repo: "hexpm", optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, repo: "hexpm", optional: false]}], "hexpm"},
+  "idna": {:hex, :idna, "5.1.0", "d72b4effeb324ad5da3cab1767cb16b17939004e789d8c0ad5b70f3cea20c89a", [], [{:unicode_util_compat, "0.3.1", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm"},
+  "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [], [], "hexpm"},
+  "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [], [], "hexpm"},
+  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [], [], "hexpm"},
+  "tzdata": {:hex, :tzdata, "0.5.12", "1c17b68692c6ba5b6ab15db3d64cc8baa0f182043d5ae9d4b6d35d70af76f67b", [], [{:hackney, "~> 1.0", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
+  "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [], [], "hexpm"}}

--- a/test/api_auth_test.exs
+++ b/test/api_auth_test.exs
@@ -2,7 +2,35 @@ defmodule ApiAuthTest do
   use ExUnit.Case
   doctest ApiAuth
 
-  test "greets the world" do
-    assert ApiAuth.hello() == :world
+  test "calculates signature" do
+    authorization = ApiAuth.authorization(
+      "/",
+      "1044",
+      "123",
+      hashed_content: "",
+      time: time(),
+      signature_hash: :sha,
+    )
+
+    assert authorization == "APIAuth 1044:49FglhLqXWuJqBu5SQOH4F8D1Og="
+  end
+
+  test "calculates signature with method, content type, and body" do
+    authorization = ApiAuth.authorization(
+      "/resource.xml?foo=bar&bar=foo",
+      "1044",
+      "123",
+      method: "PUT",
+      content_type: "text/plain",
+      time: time(),
+      content_hash: :md5,
+      signature_hash: :sha256,
+    )
+
+    assert authorization == "APIAuth 1044:5JhErRhsIbN2+O595t/Rkax2n7w/YZ0f92BYgZFN5ds="
+  end
+
+  defp time do
+    "Sat, 01 Jan 2000 00:00:00 GMT" |> Calendar.DateTime.Parse.httpdate!
   end
 end


### PR DESCRIPTION
This is the first step to creating an Elixir library that can sign API requests using Amazon-style HMAC authentication and also interface with Ruby/Rails applications that use [api_auth](https://github.com/mgomes/api_auth).

It does not represent the final state of this library's API.

What this commit does is:

* Take some tests from [api_auth](https://github.com/mgomes/api_auth/blob/4ea2e2f6abed1fdf650ec716ca86c2ed9f640b45/spec/api_auth_spec.rb#L54) and find what the value of the `Authorization` header should be for a  particular time
* Create Elixir versions of those tests
* Write a function that generates a matching `Authorization` header given the correct input

Fixes https://github.com/TheGnarCo/api_auth_ex/issues/3