### PR TITLE
Generate all HTTP headers required

### DIFF
--- a/lib/api_auth.ex
+++ b/lib/api_auth.ex
@@ -5,65 +5,125 @@ defmodule ApiAuth do
   It provides an HMAC authentication system for APIs.
   """
 
-  alias Calendar.DateTime, as: DateTime
-
   @doc """
-  Generates an Authorization header
+  Generates a map of headers which are used to authenticate the request
 
-  Returns the string "ApiAuth client_id:<signature>"
+  Returns a map with the following key value pairs:
+  %{
+    "X-APIAuth-Content-HASH" | "Content-MDS" => hash of content (if POST or PUT),
+    "DATE" => timestamp formatted as HTTP Date,
+    "Authorization" => "APIAuth user_id:signature"
+  }
 
   ## Examples
 
-      iex> ApiAuth.authorization("/foo", "id", "secret", method: "GET",
+      iex> ApiAuth.headers("/foo", "id", "secret", method: "GET",
       ...>                       time: "Sat, 01 Jan 2000 00:00:00 GMT" |> Calendar.DateTime.Parse.httpdate!)
-      "APIAuth id:Uv9YsGct6RFBFDxn5NhUPGqe+EVRQXrE5QLjVWXkga8="
+      %{"Authorization" => "APIAuth-HMAC-SHA256 id:U/HCVd3+aZpbmRwPgTufT24+Sz0F/cjRSyckW9ZdMSY=",
+        "DATE" => "Sat, 01 Jan 2000 00:00:00 GMT"}
+
+      iex> ApiAuth.headers("/bar?search=1", "id", "secret", method: "POST", content: "{\\"id\\": 1}",
+      ...>                       time: "Sat, 01 Jan 2000 00:00:00 GMT" |> Calendar.DateTime.Parse.httpdate!)
+      %{"Authorization" => "APIAuth-HMAC-SHA256 id:5dcvZxiR9GetYPjdlP6CBFh4MDAMt5e795+gnnMjbqw=",
+        "DATE" => "Sat, 01 Jan 2000 00:00:00 GMT",
+        "X-APIAuth-Content-Hash" => "NUqu96X27LsvruSfvkeiTgJMtisxg7hToezAHgGSDkk="}
 
   """
-  def authorization(uri, client_id, secret_key, opts \\ []) do
-    method         = opts |> Keyword.get(:method, "GET")
-    content_type   = opts |> Keyword.get(:content_type, "")
-    content        = opts |> Keyword.get(:content, "")
-    content_hash   = opts |> Keyword.get(:content_hash, :sha256)
-    hashed_content = opts |> Keyword.get(:hashed_content, hashed(content, content_hash))
-    time           = opts |> Keyword.get(:time, DateTime.now_utc)
-    separator      = opts |> Keyword.get(:separator, ",")
-    signature_hash = opts |> Keyword.get(:signature_hash, :sha256)
+  def headers(uri, client_id, secret_key, opts \\ []) do
+    options = parse(opts)
 
-    string = canonical_string(
-      String.upcase(method),
-      content_type,
-      hashed_content,
+    signature = canonical_string(
+      options.method,
+      options.content_type,
+      options.content_hash,
       uri,
-      timestamp(time),
-      separator
-    )
+      options.timestamp,
+      options.separator
+    ) |> signature(secret_key, options.signature_algorithm)
 
-    string
-    |> signature(secret_key, signature_hash)
-    |> header(client_id)
+    [
+      date_header(options.timestamp),
+      content_hash_header(options.method, options.content_algorithm, options.content_hash),
+      authorization_header(options.signature_algorithm, client_id, signature),
+    ] |> merge_maps()
   end
 
-  defp header(signature, client_id) do
-    "APIAuth #{client_id}:#{signature}"
+  defp parse(opts) do
+    method              = opts |> Keyword.get(:method, "GET") |> String.upcase()
+    content             = opts |> Keyword.get(:content, "")
+    content_algorithm   = opts |> Keyword.get(:content_algorithm, :sha256)
+    content_type        = opts |> Keyword.get(:content_type, "")
+    content_hash        = opts |> Keyword.get(:content_hash, content_hash(method, content, content_algorithm))
+    timestamp           = opts |> Keyword.get(:time, Calendar.DateTime.now_utc) |> timestamp()
+    separator           = opts |> Keyword.get(:separator, ",")
+    signature_algorithm = opts |> Keyword.get(:signature_algorithm, :sha256)
+
+    %{
+      method: method,
+      content: content,
+      content_algorithm: content_algorithm,
+      content_type: content_type,
+      content_hash: content_hash,
+      timestamp: timestamp,
+      separator: separator,
+      signature_algorithm: signature_algorithm,
+    }
+  end
+
+  defp date_header(time) do
+    %{ "DATE" => time }
+  end
+
+  defp content_hash_header(method, hash, content_hash) when method in ["PUT", "POST"] do
+    content_hash_header(hash, content_hash)
+  end
+
+  defp content_hash_header(_method, _hash, _content_hash) do
+    %{}
+  end
+
+  defp content_hash_header(:md5, content_hash) do
+    %{ "Content-MD5" => content_hash }
+  end
+
+  defp content_hash_header(_hash, content_hash) do
+    %{ "X-APIAuth-Content-Hash" => content_hash }
+  end
+
+  defp authorization_header(:sha256, client_id, signature) do
+    %{ "Authorization" => "APIAuth-HMAC-SHA256 #{client_id}:#{signature}" }
+  end
+
+  defp authorization_header(_hash, client_id, signature) do
+    %{ "Authorization" => "APIAuth #{client_id}:#{signature}" }
   end
 
   defp timestamp(time) do
     time
-    |> DateTime.Format.httpdate
+    |> Calendar.DateTime.Format.httpdate
   end
 
-  defp hashed(content, hash) do
+  defp content_hash(method, content, hash) when method in ["PUT", "POST"] do
     :crypto.hash(hash, content)
     |> Base.encode64()
   end
 
-  defp canonical_string(method, content_type, hashed_content, request_uri, timestamp, separator) do
-    [method, content_type, hashed_content, request_uri, timestamp]
+  defp content_hash(_method, _content, _hash) do
+    ""
+  end
+
+  defp canonical_string(method, content_type, content_hash, request_uri, timestamp, separator) do
+    [method, content_type, content_hash, request_uri, timestamp]
     |> Enum.join(separator)
   end
 
   defp signature(canonical_string, secret_key, hash) do
     :crypto.hmac(hash, secret_key, canonical_string)
     |> Base.encode64()
+  end
+
+  defp merge_maps(maps) do
+    maps
+    |> Enum.reduce(&Map.merge/2)
   end
 end

--- a/test/api_auth_test.exs
+++ b/test/api_auth_test.exs
@@ -2,32 +2,95 @@ defmodule ApiAuthTest do
   use ExUnit.Case
   doctest ApiAuth
 
-  test "calculates signature" do
-    authorization = ApiAuth.authorization(
-      "/",
-      "1044",
-      "123",
-      hashed_content: "",
-      time: time(),
-      signature_hash: :sha,
-    )
+  describe "Date header" do
+    test "adds the date to the header" do
+      %{ "DATE" => date } = ApiAuth.headers("/", "1044", "123", time: time())
 
-    assert authorization == "APIAuth 1044:49FglhLqXWuJqBu5SQOH4F8D1Og="
+      assert date == "Sat, 01 Jan 2000 00:00:00 GMT"
+    end
+
+    test "uses the current time if none is given" do
+      %{ "DATE" => date } = ApiAuth.headers("/", "1044", "123")
+
+      diff = Calendar.DateTime.now_utc()
+             |> DateTime.diff(Calendar.DateTime.Parse.httpdate!(date), :second)
+
+      assert diff == 0
+    end
   end
 
-  test "calculates signature with method, content type, and body" do
-    authorization = ApiAuth.authorization(
-      "/resource.xml?foo=bar&bar=foo",
-      "1044",
-      "123",
-      method: "PUT",
-      content_type: "text/plain",
-      time: time(),
-      content_hash: :md5,
-      signature_hash: :sha256,
-    )
+  describe "Content hash header" do
+    test "there is no content hash when it is not a POST or PUSH" do
+      headers = ApiAuth.headers("/", "1044", "123")
 
-    assert authorization == "APIAuth 1044:5JhErRhsIbN2+O595t/Rkax2n7w/YZ0f92BYgZFN5ds="
+      assert headers["X-APIAuth-Content-Hash"] == nil
+    end
+
+    test "the content hash is calculated correctly" do
+      %{ "X-APIAuth-Content-Hash" => hash } = ApiAuth.headers(
+        "/",
+        "1044",
+        "123",
+        method: "POST",
+        content: "foo",
+      )
+
+      assert hash == "LCa0a2j/xo/5m0U8HTBBNBNCLXBkg7+g+YpeiGJm564="
+    end
+
+    test "the content hash header is different for md5" do
+      %{ "Content-MD5" => hash } = ApiAuth.headers(
+        "/",
+        "1044",
+        "123",
+        method: "POST",
+        content: "foo",
+        content_algorithm: :md5,
+      )
+
+      assert hash == "rL0Y20zC+Fzt72VPzMSk2A=="
+    end
+
+    test "the content hash can be overwritten" do
+      %{ "X-APIAuth-Content-Hash" => hash } = ApiAuth.headers(
+        "/",
+        "1044",
+        "123",
+        method: "POST",
+        content: "foo",
+        content_hash: "pre-computed hash",
+      )
+
+      assert hash == "pre-computed hash"
+    end
+  end
+
+  describe "Authorization header" do
+    test "calculates signature" do
+      %{ "Authorization" => authorization } = ApiAuth.headers(
+        "/",
+        "1044",
+        "123",
+        time: time(),
+        signature_algorithm: :sha,
+      )
+
+      assert authorization == "APIAuth 1044:49FglhLqXWuJqBu5SQOH4F8D1Og="
+    end
+
+    test "calculates signature with method, content type, and body" do
+      %{ "Authorization" => authorization } = ApiAuth.headers(
+        "/resource.xml?foo=bar&bar=foo",
+        "1044",
+        "123",
+        method: "PUT",
+        content_type: "text/plain",
+        time: time(),
+        content_algorithm: :md5,
+      )
+
+      assert authorization == "APIAuth-HMAC-SHA256 1044:5JhErRhsIbN2+O595t/Rkax2n7w/YZ0f92BYgZFN5ds="
+    end
   end
 
   defp time do


### PR DESCRIPTION
The `sign!` method in [api_auth](https://github.com/mgomes/api_auth/blob/4ea2e2f6abed1fdf650ec716ca86c2ed9f640b45/spec/api_auth_spec.rb#L26) adds more than just the `Authorization` header. It also adds the following headers:

* `DATE`
* `Content-MD5`

This commit adds those headers in a way that should be compatible with `api_auth`. It replaces the `authorization` function with `headers`, and instead of returning a string, returns a map of all of the headers that should be included in the request in order to be authenticated by `api_auth`.

It also makes a few other small changes to match the behavior of `api_auth`

Fixes https://github.com/TheGnarCo/api_auth_ex/issues/4