### PR TITLE
Refactor code to use keyword list headers

### DIFF
--- a/lib/api_auth.ex
+++ b/lib/api_auth.ex
@@ -6,124 +6,34 @@ defmodule ApiAuth do
   """
 
   @doc """
-  Generates a map of headers which are used to authenticate the request
-
-  Returns a map with the following key value pairs:
-  %{
-    "X-APIAuth-Content-HASH" | "Content-MDS" => hash of content (if POST or PUT),
-    "DATE" => timestamp formatted as HTTP Date,
-    "Authorization" => "APIAuth user_id:signature"
-  }
+  Takes a keyword list of headers and arguments necessary for generating the
+  Authorization header and returns an updated keyword list of headers.
 
   ## Examples
 
-      iex> ApiAuth.headers("/foo", "id", "secret", method: "GET",
-      ...>                       time: "Sat, 01 Jan 2000 00:00:00 GMT" |> Calendar.DateTime.Parse.httpdate!)
-      %{"Authorization" => "APIAuth-HMAC-SHA256 id:U/HCVd3+aZpbmRwPgTufT24+Sz0F/cjRSyckW9ZdMSY=",
-        "DATE" => "Sat, 01 Jan 2000 00:00:00 GMT"}
-
-      iex> ApiAuth.headers("/bar?search=1", "id", "secret", method: "POST", content: "{\\"id\\": 1}",
-      ...>                       time: "Sat, 01 Jan 2000 00:00:00 GMT" |> Calendar.DateTime.Parse.httpdate!)
-      %{"Authorization" => "APIAuth-HMAC-SHA256 id:5dcvZxiR9GetYPjdlP6CBFh4MDAMt5e795+gnnMjbqw=",
-        "DATE" => "Sat, 01 Jan 2000 00:00:00 GMT",
-        "X-APIAuth-Content-Hash" => "NUqu96X27LsvruSfvkeiTgJMtisxg7hToezAHgGSDkk="}
-
+      iex> [DATE: "Sat, 01 Jan 2000 00:00:00 GMT", "Content-Type": "application/json"]
+      ...> |> ApiAuth.headers("/path", "client_id", "secret_key",
+      ...>                    method: "PUT", content: "{\\"foo\\": \\"bar\\"}")
+      [Authorization: "APIAuth-HMAC-SHA256 client_id:v5+Ooq88txd0cFyfSXYn03EFK/NQW9Gepk5YIdkZ4qM=",
+       "X-APIAuth-Content-Hash": "Qm/ATwS/j9tYMdw3u7bc9w9jo34FpoxupfY+ha5Xk3Y=",
+       DATE: "Sat, 01 Jan 2000 00:00:00 GMT",
+       "Content-Type": "application/json"]
   """
-  def headers(uri, client_id, secret_key, opts \\ []) do
-    options = parse(opts)
 
-    signature = canonical_string(
-      options.method,
-      options.content_type,
-      options.content_hash,
-      uri,
-      options.timestamp,
-      options.separator
-    ) |> signature(secret_key, options.signature_algorithm)
+  alias ApiAuth.HeaderValues
 
-    [
-      date_header(options.timestamp),
-      content_hash_header(options.method, options.content_algorithm, options.content_hash),
-      authorization_header(options.signature_algorithm, client_id, signature),
-    ] |> merge_maps()
-  end
-
-  defp parse(opts) do
+  def headers(request_headers, uri, client_id, secret_key, opts \\ []) do
     method              = opts |> Keyword.get(:method, "GET") |> String.upcase()
     content             = opts |> Keyword.get(:content, "")
     content_algorithm   = opts |> Keyword.get(:content_algorithm, :sha256)
-    content_type        = opts |> Keyword.get(:content_type, "")
-    content_hash        = opts |> Keyword.get(:content_hash, content_hash(method, content, content_algorithm))
-    timestamp           = opts |> Keyword.get(:time, Calendar.DateTime.now_utc) |> timestamp()
-    separator           = opts |> Keyword.get(:separator, ",")
     signature_algorithm = opts |> Keyword.get(:signature_algorithm, :sha256)
 
-    %{
-      method: method,
-      content: content,
-      content_algorithm: content_algorithm,
-      content_type: content_type,
-      content_hash: content_hash,
-      timestamp: timestamp,
-      separator: separator,
-      signature_algorithm: signature_algorithm,
-    }
-  end
-
-  defp date_header(time) do
-    %{ "DATE" => time }
-  end
-
-  defp content_hash_header(method, hash, content_hash) when method in ["PUT", "POST"] do
-    content_hash_header(hash, content_hash)
-  end
-
-  defp content_hash_header(_method, _hash, _content_hash) do
-    %{}
-  end
-
-  defp content_hash_header(:md5, content_hash) do
-    %{ "Content-MD5" => content_hash }
-  end
-
-  defp content_hash_header(_hash, content_hash) do
-    %{ "X-APIAuth-Content-Hash" => content_hash }
-  end
-
-  defp authorization_header(:sha256, client_id, signature) do
-    %{ "Authorization" => "APIAuth-HMAC-SHA256 #{client_id}:#{signature}" }
-  end
-
-  defp authorization_header(_hash, client_id, signature) do
-    %{ "Authorization" => "APIAuth #{client_id}:#{signature}" }
-  end
-
-  defp timestamp(time) do
-    time
-    |> Calendar.DateTime.Format.httpdate
-  end
-
-  defp content_hash(method, content, hash) when method in ["PUT", "POST"] do
-    :crypto.hash(hash, content)
-    |> Base.encode64()
-  end
-
-  defp content_hash(_method, _content, _hash) do
-    ""
-  end
-
-  defp canonical_string(method, content_type, content_hash, request_uri, timestamp, separator) do
-    [method, content_type, content_hash, request_uri, timestamp]
-    |> Enum.join(separator)
-  end
-
-  defp signature(canonical_string, secret_key, hash) do
-    :crypto.hmac(hash, secret_key, canonical_string)
-    |> Base.encode64()
-  end
-
-  defp merge_maps(maps) do
-    maps
-    |> Enum.reduce(&Map.merge/2)
+    HeaderValues.wrap(request_headers)
+    |> ApiAuth.ContentTypeHeader.headers()
+    |> ApiAuth.DateHeader.headers()
+    |> ApiAuth.UriHeader.headers(uri)
+    |> ApiAuth.ContentHashHeader.headers(method, content, content_algorithm)
+    |> ApiAuth.AuthorizationHeader.headers(method, client_id, secret_key, signature_algorithm)
+    |> HeaderValues.unwrap()
   end
 end

--- a/lib/api_auth/authorization_header.ex
+++ b/lib/api_auth/authorization_header.ex
@@ -1,0 +1,41 @@
+defmodule ApiAuth.AuthorizationHeader do
+  @moduledoc false
+
+  @keys       [:Authorization, :AUTHORIZATION]
+  @header_key :Authorization
+  @value_key  :authorization
+
+  alias ApiAuth.HeaderValues
+
+  def headers(hv, method, client_id, secret_key, algorithm) do
+    authorization = canonical_string(
+      method,
+      hv |> HeaderValues.get(:content_type),
+      hv |> HeaderValues.get(:content_hash),
+      hv |> HeaderValues.get(:uri, "/"),
+      hv |> HeaderValues.get(:timestamp)
+    )
+    |> signature(secret_key, algorithm)
+    |> header_string(client_id, algorithm)
+
+    hv |> HeaderValues.put(@keys, @header_key, @value_key, authorization)
+  end
+
+  defp canonical_string(method, content_type, content_hash, uri, timestamp) do
+    [method, content_type, content_hash, uri, timestamp]
+    |> Enum.join(",")
+  end
+
+  defp signature(canonical_string, secret_key, algorithm) do
+    :crypto.hmac(algorithm, secret_key, canonical_string)
+    |> Base.encode64()
+  end
+
+  defp header_string(signature, client_id, :sha256) do
+    "APIAuth-HMAC-SHA256 #{client_id}:#{signature}"
+  end
+
+  defp header_string(signature, client_id, _algorithm) do
+    "APIAuth #{client_id}:#{signature}"
+  end
+end

--- a/lib/api_auth/content_hash_header.ex
+++ b/lib/api_auth/content_hash_header.ex
@@ -1,0 +1,29 @@
+defmodule ApiAuth.ContentHashHeader do
+  @moduledoc false
+
+  @methods        ["PUT", "POST"]
+  @keys           [:"X-APIAuth-Content-Hash", :"X-APIAUTH-CONTENT-HASH", :X_APIAUTH_CONTENT_HASH]
+  @header_key     :"X-APIAuth-Content-Hash"
+  @md5_keys       [:"Content-MD5", :"CONTENT-MD5", :CONTENT_MD5]
+  @md5_header_key :"Content-MD5"
+  @value_key      :content_hash
+
+  alias ApiAuth.HeaderValues
+
+  def headers(hv, method, content, :md5) when method in @methods do
+    hv |> HeaderValues.put_new(@md5_keys, @md5_header_key, @value_key, hash(:md5, content))
+  end
+
+  def headers(hv, method, content, algorithm) when method in @methods do
+    hv |> HeaderValues.put_new(@keys, @header_key, @value_key, hash(algorithm, content))
+  end
+
+  def headers(hv, _method, _content, _algorithm) do
+    hv |> HeaderValues.copy(@keys, @value_key)
+  end
+
+  defp hash(algorithm, content) do
+    :crypto.hash(algorithm, content)
+    |> Base.encode64()
+  end
+end

--- a/lib/api_auth/content_type_header.ex
+++ b/lib/api_auth/content_type_header.ex
@@ -1,0 +1,10 @@
+defmodule ApiAuth.ContentTypeHeader do
+  @moduledoc false
+
+  @keys      [:"Content-Type", :"CONTENT-TYPE", :"CONTENT_TYPE", :"HTTP_CONTENT_TYPE"]
+  @value_key :content_type
+
+  def headers(hv) do
+    ApiAuth.HeaderValues.copy(hv, @keys, @value_key)
+  end
+end

--- a/lib/api_auth/date_header.ex
+++ b/lib/api_auth/date_header.ex
@@ -1,0 +1,18 @@
+defmodule ApiAuth.DateHeader do
+  @moduledoc false
+
+  @keys       [:DATE, :HTTP_DATE]
+  @header_key :DATE
+  @value_key  :timestamp
+
+  alias ApiAuth.HeaderValues
+
+  def headers(hv) do
+    hv |> HeaderValues.put_new(@keys, @header_key, @value_key, timestamp())
+  end
+
+  defp timestamp do
+    Calendar.DateTime.now_utc()
+    |> Calendar.DateTime.Format.httpdate
+  end
+end

--- a/lib/api_auth/header_values.ex
+++ b/lib/api_auth/header_values.ex
@@ -1,0 +1,55 @@
+defmodule ApiAuth.HeaderValues do
+  @moduledoc false
+
+  def wrap(headers) do
+    { headers, %{} }
+  end
+
+  def unwrap({ headers, _assigns }) do
+    headers
+  end
+
+  def transform({ headers, assigns }, key, default, fun) do
+    { headers, Map.update(assigns, key, default, fun) }
+  end
+
+  def get({ _headers, assigns }, key, default \\ "") do
+    Map.get(assigns, key, default)
+  end
+
+  def copy({ headers, assigns }, keys, value_key, default \\ "") do
+    header = Enum.find(headers, fn { k, _v } -> Enum.member?(keys, k) end)
+
+    new_assigns = case header do
+      { _k, v } -> assigns |> Map.put(value_key, v)
+      _         -> assigns |> Map.put(value_key, default)
+    end
+
+    { headers, new_assigns }
+  end
+
+  def put({ headers, assigns }, keys, header_key, value_key, default) do
+    clean_headers = Enum.reject(headers, fn { k, _v } -> Enum.member?(keys, k) end)
+
+    {
+      clean_headers  |> Keyword.put(header_key, default),
+      assigns        |> Map.put(value_key, default)
+    }
+  end
+
+  def put_new({ headers, assigns }, keys, header_key, value_key, default) do
+    header = Enum.find(headers, fn { k, _v } -> Enum.member?(keys, k) end)
+
+    new_headers = case header do
+      { _k, _v } -> headers
+      _          -> headers |> Keyword.put(header_key, default)
+    end
+
+    new_assigns = case header do
+      { _k, v } -> assigns |> Map.put(value_key, v)
+      _         -> assigns |> Map.put(value_key, default)
+    end
+
+    { new_headers, new_assigns }
+  end
+end

--- a/lib/api_auth/uri_header.ex
+++ b/lib/api_auth/uri_header.ex
@@ -1,0 +1,22 @@
+defmodule ApiAuth.UriHeader do
+  @moduledoc false
+
+  @keys      [:"X-Original-URI", :"X-ORIGINAL-URI", :"X_ORIGINAL_URI", :"HTTP_X_ORIGINAL_URI"]
+  @value_key :uri
+
+  alias ApiAuth.HeaderValues
+
+  def headers(hv, uri) do
+    hv
+    |> HeaderValues.copy(@keys, @value_key, uri)
+    |> HeaderValues.transform(@value_key, "/", &parse_uri/1)
+  end
+
+  def parse_uri(uri) do
+    %{ path: path, query: query } = URI.parse(uri)
+
+    path = if path && path != "", do: path, else: "/"
+
+    if query, do: "#{path}?#{query}", else: path
+  end
+end

--- a/test/api_auth/authorization_header_test.exs
+++ b/test/api_auth/authorization_header_test.exs
@@ -1,0 +1,57 @@
+defmodule ApiAuth.AuthorizationHeaderTest do
+  use ExUnit.Case
+
+  alias ApiAuth.AuthorizationHeader
+  alias ApiAuth.HeaderValues
+
+  describe "headers" do
+    test "it calculates the signature" do
+      headers = [DATE: "Sat, 01 Jan 2000 00:00:00 GMT"]
+      value = headers
+              |> HeaderValues.wrap()
+              |> ApiAuth.DateHeader.headers()
+              |> AuthorizationHeader.headers("GET", "1044", "123", :sha)
+              |> HeaderValues.get(:authorization)
+
+      assert value == "APIAuth 1044:49FglhLqXWuJqBu5SQOH4F8D1Og="
+    end
+
+    test "it calcualtes the signature with a body" do
+      headers = [DATE: "Sat, 01 Jan 2000 00:00:00 GMT", "Content-Type": "text/plain"]
+      value = headers
+              |> HeaderValues.wrap()
+              |> ApiAuth.DateHeader.headers()
+              |> ApiAuth.ContentTypeHeader.headers()
+              |> ApiAuth.ContentHashHeader.headers("PUT", "", :md5)
+              |> ApiAuth.UriHeader.headers("/resource.xml?foo=bar&bar=foo")
+              |> AuthorizationHeader.headers("PUT", "1044", "123", :sha256)
+              |> HeaderValues.get(:authorization)
+
+      assert value == "APIAuth-HMAC-SHA256 1044:5JhErRhsIbN2+O595t/Rkax2n7w/YZ0f92BYgZFN5ds="
+    end
+
+    test "it writes the signature to the headers" do
+      headers = [DATE: "Sat, 01 Jan 2000 00:00:00 GMT"]
+      new_headers = headers
+                    |> HeaderValues.wrap()
+                    |> ApiAuth.DateHeader.headers()
+                    |> AuthorizationHeader.headers("GET", "1044", "123", :sha)
+                    |> HeaderValues.unwrap()
+
+      assert new_headers == [Authorization: "APIAuth 1044:49FglhLqXWuJqBu5SQOH4F8D1Og=",
+                             DATE: "Sat, 01 Jan 2000 00:00:00 GMT"]
+    end
+
+    test "it overwrites the existing header" do
+      headers = [DATE: "Sat, 01 Jan 2000 00:00:00 GMT", AUTHORIZATION: "foo"]
+      new_headers = headers
+                    |> HeaderValues.wrap()
+                    |> ApiAuth.DateHeader.headers()
+                    |> AuthorizationHeader.headers("GET", "1044", "123", :sha)
+                    |> HeaderValues.unwrap()
+
+      assert new_headers == [Authorization: "APIAuth 1044:49FglhLqXWuJqBu5SQOH4F8D1Og=",
+                             DATE: "Sat, 01 Jan 2000 00:00:00 GMT"]
+    end
+  end
+end

--- a/test/api_auth/content_hash_header_test.ex
+++ b/test/api_auth/content_hash_header_test.ex
@@ -1,0 +1,90 @@
+defmodule ApiAuth.ContentHashHeaderTest do
+  use ExUnit.Case
+
+  alias ApiAuth.ContentHashHeader
+  alias ApiAuth.HeaderValues
+
+  describe "headers" do
+    test "this is not a PUT or POST and it doesn't compute the hash" do
+      headers = [foo: "bar"]
+      value = headers
+              |> HeaderValues.wrap()
+              |> ContentHashHeader.headers("GET", "", :sha256)
+              |> HeaderValues.get(:content_hash)
+
+      assert value == ""
+    end
+
+    test "it computes the content hash correctly" do
+      headers = [foo: "bar"]
+      value = headers
+              |> HeaderValues.wrap()
+              |> ContentHashHeader.headers("POST", "foo", :sha256)
+              |> HeaderValues.get(:content_hash)
+
+      assert value == "LCa0a2j/xo/5m0U8HTBBNBNCLXBkg7+g+YpeiGJm564="
+    end
+
+    test "it computes the md5 hash correctly" do
+      headers = [foo: "bar"]
+      value = headers
+              |> HeaderValues.wrap()
+              |> ContentHashHeader.headers("POST", "foo", :md5)
+              |> HeaderValues.get(:content_hash)
+
+      assert value == "rL0Y20zC+Fzt72VPzMSk2A=="
+    end
+
+    test "it gets the value from the headers" do
+      headers = ["X-APIAuth-Content-Hash": "hash", "Content-MD5": "md5-hash", foo: "bar"]
+      value = headers
+              |> HeaderValues.wrap()
+              |> ContentHashHeader.headers("POST", "foo", :sha256)
+              |> HeaderValues.get(:content_hash)
+
+      assert value == "hash"
+    end
+
+    test "it gets the md5 from the headers" do
+      headers = ["X-APIAuth-Content-Hash": "hash", "Content-MD5": "md5-hash", foo: "bar"]
+      value = headers
+              |> HeaderValues.wrap()
+              |> ContentHashHeader.headers("POST", "foo", :md5)
+              |> HeaderValues.get(:content_hash)
+
+      assert value == "md5-hash"
+    end
+
+    test "it adds to the header if there is no key" do
+      headers = [foo: "bar"]
+      value = headers
+              |> HeaderValues.wrap()
+              |> ContentHashHeader.headers("POST", "foo", :sha256)
+              |> HeaderValues.unwrap()
+              |> Keyword.fetch!(:"X-APIAuth-Content-Hash")
+
+      assert value == "LCa0a2j/xo/5m0U8HTBBNBNCLXBkg7+g+YpeiGJm564="
+    end
+
+    test "it adds to the header if there is no md5 key" do
+      headers = [foo: "bar"]
+      value = headers
+              |> HeaderValues.wrap()
+              |> ContentHashHeader.headers("POST", "foo", :md5)
+              |> HeaderValues.unwrap()
+              |> Keyword.fetch!(:"Content-MD5")
+
+      assert value == "rL0Y20zC+Fzt72VPzMSk2A=="
+    end
+
+    test "it does not change an existing header" do
+      headers = ["X-APIAuth-Content-Hash": "hash", "Content-MD5": "md5-hash", foo: "bar"]
+      new_headers = headers
+                    |> HeaderValues.wrap()
+                    |> ContentHashHeader.headers("POST", "foo", :md5)
+                    |> HeaderValues.unwrap()
+
+      assert new_headers == headers
+    end
+  end
+end

--- a/test/api_auth/content_type_header_test.exs
+++ b/test/api_auth/content_type_header_test.exs
@@ -1,0 +1,38 @@
+defmodule ApiAuth.ContentTypeHeaderTest do
+  use ExUnit.Case
+
+  alias ApiAuth.ContentTypeHeader
+  alias ApiAuth.HeaderValues
+
+  describe "headers" do
+    test "it gets the value from a content type header" do
+      headers = [foo: "bar", "Content-Type": "application/json"]
+      value = headers
+              |> HeaderValues.wrap()
+              |> ContentTypeHeader.headers()
+              |> HeaderValues.get(:content_type)
+
+      assert value == "application/json"
+    end
+
+    test "it sets a default value of empty string" do
+      headers = [foo: "bar"]
+      value = headers
+              |> HeaderValues.wrap()
+              |> ContentTypeHeader.headers()
+              |> HeaderValues.get(:content_type)
+
+      assert value == ""
+    end
+
+    test "it does not change the headers" do
+      headers = [foo: "bar"]
+      new_headers = headers
+                    |> HeaderValues.wrap()
+                    |> ContentTypeHeader.headers()
+                    |> HeaderValues.unwrap()
+
+      assert new_headers == headers
+    end
+  end
+end

--- a/test/api_auth/date_header_test.exs
+++ b/test/api_auth/date_header_test.exs
@@ -1,0 +1,56 @@
+defmodule ApiAuth.DateHeaderTest do
+  use ExUnit.Case
+
+  alias ApiAuth.DateHeader
+  alias ApiAuth.HeaderValues
+
+  describe "headers" do
+    test "it gets the value from the headers" do
+      headers = [HTTP_DATE: "Sat, 01 Jan 2000 00:00:00 GMT"]
+      value = headers
+              |> HeaderValues.wrap()
+              |> DateHeader.headers()
+              |> HeaderValues.get(:timestamp)
+
+      assert value == "Sat, 01 Jan 2000 00:00:00 GMT"
+    end
+
+    test "it defaults to the current time if not set" do
+      headers = []
+      value = headers
+              |> HeaderValues.wrap()
+              |> DateHeader.headers()
+              |> HeaderValues.get(:timestamp)
+
+      diff = Calendar.DateTime.now_utc()
+             |> DateTime.diff(Calendar.DateTime.Parse.httpdate!(value), :second)
+
+      assert diff == 0
+    end
+
+    test "it adds to the header if there is no key" do
+      headers = []
+
+      value = headers
+              |> HeaderValues.wrap()
+              |> DateHeader.headers()
+              |> HeaderValues.unwrap()
+              |> Keyword.fetch!(:DATE)
+
+      diff = Calendar.DateTime.now_utc()
+             |> DateTime.diff(Calendar.DateTime.Parse.httpdate!(value), :second)
+
+      assert diff == 0
+    end
+
+    test "it does not change an existing header" do
+      headers = [HTTP_DATE: "Sat, 01 Jan 2000 00:00:00 GMT"]
+      new_headers = headers
+                    |> HeaderValues.wrap()
+                    |> DateHeader.headers()
+                    |> HeaderValues.unwrap()
+
+      assert new_headers == headers
+    end
+  end
+end

--- a/test/api_auth/header_values_test.exs
+++ b/test/api_auth/header_values_test.exs
@@ -1,0 +1,125 @@
+defmodule ApiAuth.HeaderValuesTest do
+  use ExUnit.Case
+
+  alias ApiAuth.HeaderValues
+
+  describe "wrap" do
+    test "it wraps headers in a header values structure" do
+      header_values = [hello: "world", a: 1]
+                      |> HeaderValues.wrap
+
+      assert header_values == { [hello: "world", a: 1], %{} }
+    end
+  end
+
+  describe "unwrap" do
+    test "it returns the header from a header values structure" do
+      headers = { [hello: "world", a: 1], %{} }
+                |> HeaderValues.unwrap
+
+      assert headers == [hello: "world", a: 1]
+    end
+
+    test "calling wrap and unwrap returns the original list" do
+      list = [hello: "world", a: 1]
+      new_list = list |> HeaderValues.wrap |> HeaderValues.unwrap
+
+      assert list == new_list
+    end
+  end
+
+  describe "transform" do
+    test "it transforms the values without changing the headers" do
+      header_values = { [hello: "world", a: 1], %{ a: 1 } }
+      new_header_values = header_values
+                          |> HeaderValues.transform(:a, nil, &(&1 + 1))
+
+      assert new_header_values == { [hello: "world", a: 1], %{ a: 2 } }
+    end
+
+    test "it uses the default if there is no matching value" do
+      header_values = { [hello: "world", a: 1], %{ a: 1 } }
+      new_header_values = header_values
+                          |> HeaderValues.transform(:b, 15, &(&1 + 1))
+
+      assert new_header_values == { [hello: "world", a: 1], %{ a: 1, b: 15 } }
+    end
+  end
+
+  describe "get" do
+    test "it gets the value" do
+      header_values = { [hello: "world", a: 1], %{ a: 1 } }
+      value = HeaderValues.get(header_values, :a)
+
+      assert value == 1
+    end
+
+    test "it returns the empty string if there is no match" do
+      header_values = { [hello: "world", a: 1], %{ a: 1 } }
+      value = HeaderValues.get(header_values, :hello)
+
+      assert value == ""
+    end
+
+    test "it returns the default if there is no match and a default is passed in" do
+      header_values = { [hello: "world", a: 1], %{ a: 1 } }
+      value = HeaderValues.get(header_values, :hello, "default")
+
+      assert value == "default"
+    end
+  end
+
+  describe "copy" do
+    test "there is no matching header so it uses the default value" do
+      header_values = { [hello: "world", a: 1], %{ a: 1 } }
+      new_header_values = header_values
+                          |> HeaderValues.copy([:Other], :other, "foo")
+
+      assert new_header_values == { [hello: "world", a: 1], %{ a: 1, other: "foo" } }
+    end
+
+    test "it uses the value from the header" do
+      header_values = { [hello: "world", a: 1], %{ a: 1 } }
+      new_header_values = header_values
+                          |> HeaderValues.copy([:Other, :hello], :other, "foo")
+
+      assert new_header_values == { [hello: "world", a: 1], %{ a: 1, other: "world" } }
+    end
+  end
+
+  describe "put" do
+    test "there is no matching header so it uses the default value" do
+      header_values = { [hello: "world", a: 1], %{ a: 1 } }
+      new_header_values = header_values
+                          |> HeaderValues.put([:Other], :Other, :other, "foo")
+
+      assert new_header_values == { [Other: "foo", hello: "world", a: 1], %{ a: 1, other: "foo" } }
+    end
+
+    test "it uses the default value" do
+      header_values = { [hello: "world", a: 1], %{ a: 1 } }
+      new_header_values = header_values
+                          |> HeaderValues.put([:Other, :hello], :Other, :other, "foo")
+
+      assert new_header_values == { [Other: "foo", a: 1], %{ a: 1, other: "foo" } }
+    end
+  end
+
+  describe "put_new" do
+    test "there is no matching header so it uses the default value" do
+      header_values = { [hello: "world", a: 1], %{ a: 1 } }
+      new_header_values = header_values
+                          |> HeaderValues.put_new([:Other], :Other, :other, "foo")
+
+      assert new_header_values == { [Other: "foo", hello: "world", a: 1], %{ a: 1, other: "foo" } }
+    end
+
+    test "it uses the value from the header" do
+      header_values = { [hello: "world", a: 1], %{ a: 1 } }
+      new_header_values = header_values
+                          |> HeaderValues.put_new([:Other, :hello], :Other, :other, "foo")
+
+      assert new_header_values == { [hello: "world", a: 1], %{ a: 1, other: "world" } }
+    end
+  end
+end

--- a/test/api_auth/uri_header_test.exs
+++ b/test/api_auth/uri_header_test.exs
@@ -1,0 +1,58 @@
+defmodule ApiAuth.UriHeaderTest do
+  use ExUnit.Case
+
+  alias ApiAuth.UriHeader
+  alias ApiAuth.HeaderValues
+
+  describe "headers" do
+    test "it gets the value from a content type header" do
+      headers = [foo: "bar", "X-Original-URI": "/test"]
+      value = headers
+              |> HeaderValues.wrap()
+              |> UriHeader.headers("/other")
+              |> HeaderValues.get(:uri)
+
+      assert value == "/test"
+    end
+
+    test "it sets a default value of empty string" do
+      headers = [foo: "bar"]
+      value = headers
+              |> HeaderValues.wrap()
+              |> UriHeader.headers("/other")
+              |> HeaderValues.get(:uri)
+
+      assert value == "/other"
+    end
+
+    test "it does not change the headers" do
+      headers = [foo: "bar"]
+      new_headers = headers
+                    |> HeaderValues.wrap()
+                    |> UriHeader.headers("/other")
+                    |> HeaderValues.unwrap()
+
+      assert new_headers == headers
+    end
+
+    test "it removes the host part of the uri" do
+      headers = [foo: "bar", "X-Original-URI": "https://www.example.com/test?redirect=https://www.google.com"]
+      value = headers
+              |> HeaderValues.wrap()
+              |> UriHeader.headers("/other")
+              |> HeaderValues.get(:uri)
+
+      assert value == "/test?redirect=https://www.google.com"
+    end
+
+    test "the default uri is /" do
+      headers = [foo: "bar", "X-Original-URI": "https://www.example.com"]
+      value = headers
+              |> HeaderValues.wrap()
+              |> UriHeader.headers("/other")
+              |> HeaderValues.get(:uri)
+
+      assert value == "/"
+    end
+  end
+end

--- a/test/api_auth_test.exs
+++ b/test/api_auth_test.exs
@@ -2,98 +2,18 @@ defmodule ApiAuthTest do
   use ExUnit.Case
   doctest ApiAuth
 
-  describe "Date header" do
-    test "adds the date to the header" do
-      %{ "DATE" => date } = ApiAuth.headers("/", "1044", "123", time: time())
+  describe "headers" do
+    test "adds missing headers and signs request" do
+      headers = [DATE: "Sat, 01 Jan 2000 00:00:00 GMT"]
+                |> ApiAuth.headers("/", "1044", "123", method: "POST")
 
-      assert date == "Sat, 01 Jan 2000 00:00:00 GMT"
+      expected_headers = [
+        Authorization: "APIAuth-HMAC-SHA256 1044:0GZ7kEF4vXa5wjyLYsddgW66Vp1i1i8jA+CO9+9umSI=",
+        "X-APIAuth-Content-Hash": "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=",
+        DATE: "Sat, 01 Jan 2000 00:00:00 GMT",
+      ]
+
+      assert headers == expected_headers
     end
-
-    test "uses the current time if none is given" do
-      %{ "DATE" => date } = ApiAuth.headers("/", "1044", "123")
-
-      diff = Calendar.DateTime.now_utc()
-             |> DateTime.diff(Calendar.DateTime.Parse.httpdate!(date), :second)
-
-      assert diff == 0
-    end
-  end
-
-  describe "Content hash header" do
-    test "there is no content hash when it is not a POST or PUSH" do
-      headers = ApiAuth.headers("/", "1044", "123")
-
-      assert headers["X-APIAuth-Content-Hash"] == nil
-    end
-
-    test "the content hash is calculated correctly" do
-      %{ "X-APIAuth-Content-Hash" => hash } = ApiAuth.headers(
-        "/",
-        "1044",
-        "123",
-        method: "POST",
-        content: "foo",
-      )
-
-      assert hash == "LCa0a2j/xo/5m0U8HTBBNBNCLXBkg7+g+YpeiGJm564="
-    end
-
-    test "the content hash header is different for md5" do
-      %{ "Content-MD5" => hash } = ApiAuth.headers(
-        "/",
-        "1044",
-        "123",
-        method: "POST",
-        content: "foo",
-        content_algorithm: :md5,
-      )
-
-      assert hash == "rL0Y20zC+Fzt72VPzMSk2A=="
-    end
-
-    test "the content hash can be overwritten" do
-      %{ "X-APIAuth-Content-Hash" => hash } = ApiAuth.headers(
-        "/",
-        "1044",
-        "123",
-        method: "POST",
-        content: "foo",
-        content_hash: "pre-computed hash",
-      )
-
-      assert hash == "pre-computed hash"
-    end
-  end
-
-  describe "Authorization header" do
-    test "calculates signature" do
-      %{ "Authorization" => authorization } = ApiAuth.headers(
-        "/",
-        "1044",
-        "123",
-        time: time(),
-        signature_algorithm: :sha,
-      )
-
-      assert authorization == "APIAuth 1044:49FglhLqXWuJqBu5SQOH4F8D1Og="
-    end
-
-    test "calculates signature with method, content type, and body" do
-      %{ "Authorization" => authorization } = ApiAuth.headers(
-        "/resource.xml?foo=bar&bar=foo",
-        "1044",
-        "123",
-        method: "PUT",
-        content_type: "text/plain",
-        time: time(),
-        content_algorithm: :md5,
-      )
-
-      assert authorization == "APIAuth-HMAC-SHA256 1044:5JhErRhsIbN2+O595t/Rkax2n7w/YZ0f92BYgZFN5ds="
-    end
-  end
-
-  defp time do
-    "Sat, 01 Jan 2000 00:00:00 GMT" |> Calendar.DateTime.Parse.httpdate!
   end
 end


### PR DESCRIPTION
Refactor the code to

* Use a keyword list instead of a map for the headers (there can be duplicate headers)
* Take in a list of headers and some arguments and return an updated list of headers instead of taking in a bunch of arguments and returning a map of new headers
* Introduce a data structure called `HeaderValues` which contains a list of headers and a map of values.
* Have each header be a module with a `headers` function that accepts a `HeaderValues` data structure as its first argument. This way they can be piped together like this:
  ```elixir
  headers                          # keyword list of headers
  |> ApiAuth.HeaderValues.wrap()   # returns header values data structure
  |> ApiAuth.DateHeader.headers()  # adds a date header if it doesn't
                                   # exist, then copy the date header's
                                   # value into the `values` part of the
                                   # data structure
  |> ApiAuth.AuthorizationHeader() # using the date value in `values`,
                                   # generates an authorization header
                                   # for authentication
  |> ApiAuth.HeaderValues.unwrap() # returns the updated headers
  ```