### PR TITLE
Add credo and address warnings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,3 +9,4 @@ jobs:
       - run: mix local.rebar --force
       - run: mix deps.get
       - run: mix test
+      - run: mix credo

--- a/lib/api_auth.ex
+++ b/lib/api_auth.ex
@@ -21,6 +21,12 @@ defmodule ApiAuth do
   """
 
   alias ApiAuth.HeaderValues
+  alias ApiAuth.ContentTypeHeader
+  alias ApiAuth.DateHeader
+  alias ApiAuth.UriHeader
+  alias ApiAuth.ContentHashHeader
+  alias ApiAuth.ContentHashHeader
+  alias ApiAuth.AuthorizationHeader
 
   def headers(request_headers, uri, client_id, secret_key, opts \\ []) do
     method              = opts |> Keyword.get(:method, "GET") |> String.upcase()
@@ -28,12 +34,13 @@ defmodule ApiAuth do
     content_algorithm   = opts |> Keyword.get(:content_algorithm, :sha256)
     signature_algorithm = opts |> Keyword.get(:signature_algorithm, :sha256)
 
-    HeaderValues.wrap(request_headers)
-    |> ApiAuth.ContentTypeHeader.headers()
-    |> ApiAuth.DateHeader.headers()
-    |> ApiAuth.UriHeader.headers(uri)
-    |> ApiAuth.ContentHashHeader.headers(method, content, content_algorithm)
-    |> ApiAuth.AuthorizationHeader.headers(method, client_id, secret_key, signature_algorithm)
+    request_headers
+    |> HeaderValues.wrap()
+    |> ContentTypeHeader.headers()
+    |> DateHeader.headers()
+    |> UriHeader.headers(uri)
+    |> ContentHashHeader.headers(method, content, content_algorithm)
+    |> AuthorizationHeader.headers(method, client_id, secret_key, signature_algorithm)
     |> HeaderValues.unwrap()
   end
 end

--- a/lib/api_auth/authorization_header.ex
+++ b/lib/api_auth/authorization_header.ex
@@ -8,15 +8,17 @@ defmodule ApiAuth.AuthorizationHeader do
   alias ApiAuth.HeaderValues
 
   def headers(hv, method, client_id, secret_key, algorithm) do
-    authorization = canonical_string(
+    string = canonical_string(
       method,
       hv |> HeaderValues.get(:content_type),
       hv |> HeaderValues.get(:content_hash),
       hv |> HeaderValues.get(:uri, "/"),
       hv |> HeaderValues.get(:timestamp)
     )
-    |> signature(secret_key, algorithm)
-    |> header_string(client_id, algorithm)
+
+    authorization = string
+                    |> signature(secret_key, algorithm)
+                    |> header_string(client_id, algorithm)
 
     hv |> HeaderValues.put(@keys, @header_key, @value_key, authorization)
   end
@@ -27,7 +29,8 @@ defmodule ApiAuth.AuthorizationHeader do
   end
 
   defp signature(canonical_string, secret_key, algorithm) do
-    :crypto.hmac(algorithm, secret_key, canonical_string)
+    algorithm
+    |> :crypto.hmac(secret_key, canonical_string)
     |> Base.encode64()
   end
 

--- a/lib/api_auth/content_hash_header.ex
+++ b/lib/api_auth/content_hash_header.ex
@@ -11,11 +11,15 @@ defmodule ApiAuth.ContentHashHeader do
   alias ApiAuth.HeaderValues
 
   def headers(hv, method, content, :md5) when method in @methods do
-    hv |> HeaderValues.put_new(@md5_keys, @md5_header_key, @value_key, hash(:md5, content))
+    content_hash = hash(:md5, content)
+
+    hv |> HeaderValues.put_new(@md5_keys, @md5_header_key, @value_key, content_hash)
   end
 
   def headers(hv, method, content, algorithm) when method in @methods do
-    hv |> HeaderValues.put_new(@keys, @header_key, @value_key, hash(algorithm, content))
+    content_hash = hash(algorithm, content)
+
+    hv |> HeaderValues.put_new(@keys, @header_key, @value_key, content_hash)
   end
 
   def headers(hv, _method, _content, _algorithm) do
@@ -23,7 +27,8 @@ defmodule ApiAuth.ContentHashHeader do
   end
 
   defp hash(algorithm, content) do
-    :crypto.hash(algorithm, content)
+    algorithm
+    |> :crypto.hash(content)
     |> Base.encode64()
   end
 end

--- a/lib/api_auth/content_type_header.ex
+++ b/lib/api_auth/content_type_header.ex
@@ -4,7 +4,9 @@ defmodule ApiAuth.ContentTypeHeader do
   @keys      [:"Content-Type", :"CONTENT-TYPE", :"CONTENT_TYPE", :"HTTP_CONTENT_TYPE"]
   @value_key :content_type
 
+  alias ApiAuth.HeaderValues
+
   def headers(hv) do
-    ApiAuth.HeaderValues.copy(hv, @keys, @value_key)
+    HeaderValues.copy(hv, @keys, @value_key)
   end
 end

--- a/lib/api_auth/date_header.ex
+++ b/lib/api_auth/date_header.ex
@@ -6,13 +6,15 @@ defmodule ApiAuth.DateHeader do
   @value_key  :timestamp
 
   alias ApiAuth.HeaderValues
+  alias Calendar.DateTime
+  alias Calendar.DateTime.Format
 
   def headers(hv) do
     hv |> HeaderValues.put_new(@keys, @header_key, @value_key, timestamp())
   end
 
   defp timestamp do
-    Calendar.DateTime.now_utc()
-    |> Calendar.DateTime.Format.httpdate
+    DateTime.now_utc()
+    |> Format.httpdate
   end
 end

--- a/lib/api_auth/header_values.ex
+++ b/lib/api_auth/header_values.ex
@@ -2,34 +2,34 @@ defmodule ApiAuth.HeaderValues do
   @moduledoc false
 
   def wrap(headers) do
-    { headers, %{} }
+    {headers, %{}}
   end
 
-  def unwrap({ headers, _assigns }) do
+  def unwrap({headers, _assigns}) do
     headers
   end
 
-  def transform({ headers, assigns }, key, default, fun) do
-    { headers, Map.update(assigns, key, default, fun) }
+  def transform({headers, assigns}, key, default, fun) do
+    {headers, Map.update(assigns, key, default, fun)}
   end
 
-  def get({ _headers, assigns }, key, default \\ "") do
+  def get({_headers, assigns}, key, default \\ "") do
     Map.get(assigns, key, default)
   end
 
-  def copy({ headers, assigns }, keys, value_key, default \\ "") do
-    header = Enum.find(headers, fn { k, _v } -> Enum.member?(keys, k) end)
+  def copy({headers, assigns}, keys, value_key, default \\ "") do
+    header = Enum.find(headers, member(keys))
 
     new_assigns = case header do
-      { _k, v } -> assigns |> Map.put(value_key, v)
+      {_k, v} -> assigns |> Map.put(value_key, v)
       _         -> assigns |> Map.put(value_key, default)
     end
 
-    { headers, new_assigns }
+    {headers, new_assigns}
   end
 
-  def put({ headers, assigns }, keys, header_key, value_key, default) do
-    clean_headers = Enum.reject(headers, fn { k, _v } -> Enum.member?(keys, k) end)
+  def put({headers, assigns}, keys, header_key, value_key, default) do
+    clean_headers = Enum.reject(headers, member(keys))
 
     {
       clean_headers  |> Keyword.put(header_key, default),
@@ -37,19 +37,23 @@ defmodule ApiAuth.HeaderValues do
     }
   end
 
-  def put_new({ headers, assigns }, keys, header_key, value_key, default) do
-    header = Enum.find(headers, fn { k, _v } -> Enum.member?(keys, k) end)
+  def put_new({headers, assigns}, keys, header_key, value_key, default) do
+    header = Enum.find(headers, member(keys))
 
     new_headers = case header do
-      { _k, _v } -> headers
+      {_k, _v} -> headers
       _          -> headers |> Keyword.put(header_key, default)
     end
 
     new_assigns = case header do
-      { _k, v } -> assigns |> Map.put(value_key, v)
+      {_k, v} -> assigns |> Map.put(value_key, v)
       _         -> assigns |> Map.put(value_key, default)
     end
 
-    { new_headers, new_assigns }
+    {new_headers, new_assigns}
+  end
+
+  defp member(keys) do
+    fn {k, _v} -> Enum.member?(keys, k) end
   end
 end

--- a/lib/api_auth/uri_header.ex
+++ b/lib/api_auth/uri_header.ex
@@ -13,7 +13,7 @@ defmodule ApiAuth.UriHeader do
   end
 
   def parse_uri(uri) do
-    %{ path: path, query: query } = URI.parse(uri)
+    %{path: path, query: query} = URI.parse(uri)
 
     path = if path && path != "", do: path, else: "/"
 

--- a/mix.exs
+++ b/mix.exs
@@ -20,6 +20,7 @@ defmodule ApiAuth.Mixfile do
   defp deps do
     [
       {:calendar, "~> 0.17"},
+      {:credo, "~> 0.8", only: [:dev, :test], runtime: false},
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,7 @@
-%{"calendar": {:hex, :calendar, "0.17.3", "eb5db3142cb808ce1d6d604e61d50e50bc0576da03cb9202b0993e97e8045d37", [:mix], [{:tzdata, "~> 0.5.8 or ~> 0.1.201603", [hex: :tzdata, repo: "hexpm", optional: false]}], "hexpm"},
+%{"bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [], [], "hexpm"},
+  "calendar": {:hex, :calendar, "0.17.3", "eb5db3142cb808ce1d6d604e61d50e50bc0576da03cb9202b0993e97e8045d37", [:mix], [{:tzdata, "~> 0.5.8 or ~> 0.1.201603", [hex: :tzdata, repo: "hexpm", optional: false]}], "hexpm"},
   "certifi": {:hex, :certifi, "2.0.0", "a0c0e475107135f76b8c1d5bc7efb33cd3815cb3cf3dea7aefdd174dabead064", [], [], "hexpm"},
+  "credo": {:hex, :credo, "0.8.4", "4e50acac058cf6292d6066e5b0d03da5e1483702e1ccde39abba385c9f03ead4", [], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}], "hexpm"},
   "hackney": {:hex, :hackney, "1.9.0", "51c506afc0a365868469dcfc79a9d0b94d896ec741cfd5bd338f49a5ec515bfe", [], [{:certifi, "2.0.0", [hex: :certifi, repo: "hexpm", optional: false]}, {:idna, "5.1.0", [hex: :idna, repo: "hexpm", optional: false]}, {:metrics, "1.0.1", [hex: :metrics, repo: "hexpm", optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, repo: "hexpm", optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, repo: "hexpm", optional: false]}], "hexpm"},
   "idna": {:hex, :idna, "5.1.0", "d72b4effeb324ad5da3cab1767cb16b17939004e789d8c0ad5b70f3cea20c89a", [], [{:unicode_util_compat, "0.3.1", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm"},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [], [], "hexpm"},


### PR DESCRIPTION
Fixes all warnings generated by `mix credo`.

Add credo to the circle yaml

There are still some line-length warnings that come up with `mix credo --strict`, but I don't think they're worth addressing.

Fixes https://github.com/TheGnarCo/api_auth_ex/issues/11