### PR TITLE
Add client_id function

### DIFF
--- a/lib/api_auth.ex
+++ b/lib/api_auth.ex
@@ -71,6 +71,26 @@ defmodule ApiAuth do
     |> HeaderCompare.to_boolean()
   end
 
+  @doc """
+  Takes a keyword list of headers and pulls the client id from the Authorization header
+  returns the {:ok, client_id} or {:error}
+
+  ## Examples
+
+      iex> headers = [Authorization: "APIAuth-HMAC-SHA256 client_id:v5+Ooq88txd0cFyfSXYn03EFK/NQW9Gepk5YIdkZ4qM="]
+      ...> ApiAuth.client_id(headers)
+      {:ok, "client_id"}
+
+      iex> headers = []
+      ...> ApiAuth.client_id(headers)
+      :error
+
+  """
+  def client_id(headers) do
+    headers
+    |> AuthorizationHeader.extract_client_id()
+  end
+
   defp valid_headers(request_headers, uri, client_id, secret_key, opts) do
     parsed = parse(opts)
 

--- a/lib/api_auth/header_compare.ex
+++ b/lib/api_auth/header_compare.ex
@@ -1,6 +1,8 @@
 defmodule ApiAuth.HeaderCompare do
   @moduledoc false
 
+  alias ApiAuth.Utils
+
   def wrap(valid, request) do
     {:ok, valid, request}
   end
@@ -10,8 +12,8 @@ defmodule ApiAuth.HeaderCompare do
   end
 
   def compare({:ok, valid, request} = hc, keys, fun) do
-    with {:ok, valid_value}   <- find(valid, keys),
-         {:ok, request_value} <- find(request, keys),
+    with {:ok, valid_value}   <- Utils.find(valid, keys),
+         {:ok, request_value} <- Utils.find(request, keys),
          true                 <- fun.(valid_value, request_value)
     do
       hc
@@ -30,14 +32,5 @@ defmodule ApiAuth.HeaderCompare do
 
   def to_boolean(_hc) do
     false
-  end
-
-  defp find(headers, keys) do
-    pair = Enum.find(headers, fn {k, _v} -> Enum.member?(keys, k) end)
-
-    case pair do
-      {_k, v} -> {:ok, v}
-      _       -> :error
-    end
   end
 end

--- a/lib/api_auth/header_values.ex
+++ b/lib/api_auth/header_values.ex
@@ -1,6 +1,8 @@
 defmodule ApiAuth.HeaderValues do
   @moduledoc false
 
+  alias ApiAuth.Utils
+
   def wrap(headers) do
     {headers, %{}}
   end
@@ -18,18 +20,18 @@ defmodule ApiAuth.HeaderValues do
   end
 
   def copy({headers, assigns}, keys, value_key, default \\ "") do
-    header = Enum.find(headers, member(keys))
+    header = Utils.find(headers, keys)
 
     new_assigns = case header do
-      {_k, v} -> assigns |> Map.put(value_key, v)
-      _       -> assigns |> Map.put(value_key, default)
+      {:ok, v} -> assigns |> Map.put(value_key, v)
+      _        -> assigns |> Map.put(value_key, default)
     end
 
     {headers, new_assigns}
   end
 
   def put({headers, assigns}, keys, header_key, value_key, default) do
-    clean_headers = Enum.reject(headers, member(keys))
+    clean_headers = Utils.reject(headers, keys)
 
     {
       clean_headers  |> Keyword.put(header_key, default),
@@ -38,22 +40,18 @@ defmodule ApiAuth.HeaderValues do
   end
 
   def put_new({headers, assigns}, keys, header_key, value_key, default) do
-    header = Enum.find(headers, member(keys))
+    header = Utils.find(headers, keys)
 
     new_headers = case header do
-      {_k, _v} -> headers
-      _        -> headers |> Keyword.put(header_key, default)
+      {:ok, _v} -> headers
+      _         -> headers |> Keyword.put(header_key, default)
     end
 
     new_assigns = case header do
-      {_k, v} -> assigns |> Map.put(value_key, v)
-      _       -> assigns |> Map.put(value_key, default)
+      {:ok, v} -> assigns |> Map.put(value_key, v)
+      _        -> assigns |> Map.put(value_key, default)
     end
 
     {new_headers, new_assigns}
-  end
-
-  defp member(keys) do
-    fn {k, _v} -> Enum.member?(keys, k) end
   end
 end

--- a/lib/api_auth/utils.ex
+++ b/lib/api_auth/utils.ex
@@ -1,0 +1,20 @@
+defmodule ApiAuth.Utils do
+  @moduledoc false
+
+  def find(headers, keys) do
+    pair = Enum.find(headers, member_fun(keys))
+
+    case pair do
+      {_k, v} -> {:ok, v}
+      _       -> :error
+    end
+  end
+
+  def reject(headers, keys) do
+    Enum.reject(headers, member_fun(keys))
+  end
+
+  defp member_fun(keys) do
+    fn {k, _v} -> Enum.member?(keys, k) end
+  end
+end

--- a/test/api_auth/authorization_header_test.exs
+++ b/test/api_auth/authorization_header_test.exs
@@ -90,4 +90,51 @@ defmodule ApiAuth.AuthorizationHeaderTest do
       |> refute()
     end
   end
+
+  describe "extract_client_id" do
+    test "it extracts the client id" do
+      headers = [Authorization: "APIAuth-HMAC-SHA256 test:v5+Ooq88txd0cFyfSXYn03EFK/NQW9Gepk5YIdkZ4qM="]
+
+      client_id = headers
+                  |> AuthorizationHeader.extract_client_id()
+
+      assert client_id == {:ok, "test"}
+    end
+
+    test "it works with different kinds of authorization headers" do
+      headers = [AUTHORIZATION: "APIAuth 1044:49FglhLqXWuJqBu5SQOH4F8D1Og="]
+
+      client_id = headers
+                  |> AuthorizationHeader.extract_client_id()
+
+      assert client_id == {:ok, "1044"}
+    end
+
+    test "it returns an error when there is no client id" do
+      headers = [Authorization: "APIAuth-HMAC-SHA256 :v5+Ooq88txd0cFyfSXYn03EFK/NQW9Gepk5YIdkZ4qM="]
+
+      client_id = headers
+                  |> AuthorizationHeader.extract_client_id()
+
+      assert client_id == :error
+    end
+
+    test "it returns an error when the authorization header is nonsense" do
+      headers = [Authorization: "zoboomafoo"]
+
+      client_id = headers
+                  |> AuthorizationHeader.extract_client_id()
+
+      assert client_id == :error
+    end
+
+    test "it returns an error when there is no authorization header" do
+      headers = []
+
+      client_id = headers
+                  |> AuthorizationHeader.extract_client_id()
+
+      assert client_id == :error
+    end
+  end
 end

--- a/test/api_auth/utils_test.exs
+++ b/test/api_auth/utils_test.exs
@@ -1,0 +1,36 @@
+defmodule ApiAuth.UtilsTest do
+  use ExUnit.Case
+
+  alias ApiAuth.Utils
+
+  describe "find" do
+    test "it returns a tuple with :ok if it finds one of the keys" do
+      headers = [hello: "world", foo: "bar"]
+
+      found = headers
+              |> Utils.find([:test, :foo])
+
+      assert found == {:ok, "bar"}
+    end
+
+    test "it returns :error if it doesn't find one of the keys" do
+      headers = [hello: "world", foo: "bar"]
+
+      found = headers
+              |> Utils.find([:other])
+
+      assert found == :error
+    end
+  end
+
+  describe "reject" do
+    test "it returns the list without the given keys" do
+      headers = [hello: "world", foo: "bar", baz: "xyz"]
+
+      new_headers = headers
+                    |> Utils.reject([:foo, :baz])
+
+      assert new_headers == [hello: "world"]
+    end
+  end
+end


### PR DESCRIPTION
- [x] https://github.com/TheGnarCo/api_auth_ex/pull/13

Add a `client_id` function that takes a keyword list of headers and returns `{:ok, client_id}` or `:error`.

It uses the same regular expression as [here](https://github.com/mgomes/api_auth/blob/4ea2e2f6abed1fdf650ec716ca86c2ed9f640b45/lib/api_auth/base.rb#L74)

Fixes https://github.com/TheGnarCo/api_auth_ex/issues/14