### PR TITLE
Upcase and atomize header keys

### DIFF
--- a/lib/api_auth.ex
+++ b/lib/api_auth.ex
@@ -7,6 +7,7 @@ defmodule ApiAuth do
 
   alias ApiAuth.HeaderValues
   alias ApiAuth.HeaderCompare
+  alias ApiAuth.Utils
 
   alias ApiAuth.ContentTypeHeader
   alias ApiAuth.DateHeader
@@ -34,6 +35,7 @@ defmodule ApiAuth do
     parsed = parse(opts)
 
     request_headers
+    |> Utils.convert()
     |> HeaderValues.wrap()
     |> ContentTypeHeader.headers()
     |> DateHeader.headers()
@@ -61,10 +63,12 @@ defmodule ApiAuth do
   def authentic?(request_headers, uri, client_id, secret_key, opts \\ []) do
     parsed = parse(opts)
 
-    valid = valid_headers(request_headers, uri, client_id, secret_key, opts)
+    converted_headers = Utils.convert(request_headers)
+
+    valid = valid_headers(converted_headers, uri, client_id, secret_key, opts)
 
     valid
-    |> HeaderCompare.wrap(request_headers)
+    |> HeaderCompare.wrap(converted_headers)
     |> ContentHashHeader.compare(parsed.method)
     |> AuthorizationHeader.compare()
     |> DateHeader.compare()

--- a/lib/api_auth/utils.ex
+++ b/lib/api_auth/utils.ex
@@ -14,7 +14,23 @@ defmodule ApiAuth.Utils do
     Enum.reject(headers, member_fun(keys))
   end
 
+  def convert(headers) do
+    Enum.map(headers, &convert_key/1)
+  end
+
   defp member_fun(keys) do
     fn {k, _v} -> Enum.member?(keys, k) end
+  end
+
+  defp convert_key({key, value}) when is_bitstring(key) do
+    new_key = key
+              |> String.upcase()
+              |> String.to_atom()
+
+    {new_key, value}
+  end
+
+  defp convert_key(tuple) do
+    tuple
   end
 end

--- a/test/api_auth/utils_test.exs
+++ b/test/api_auth/utils_test.exs
@@ -33,4 +33,27 @@ defmodule ApiAuth.UtilsTest do
       assert new_headers == [hello: "world"]
     end
   end
+
+  describe "convert" do
+    test "it returns a keyword list unchanged" do
+      headers = [a: "1", b: "2", c: "3"]
+      new_headers = Utils.convert(headers)
+
+      assert new_headers == headers
+    end
+
+    test "give a list of {string,string} tuples it returns a keyword list" do
+      headers = [{"A", 1}, {"B", 2}]
+      new_headers = Utils.convert(headers)
+
+      assert new_headers == [A: 1, B: 2]
+    end
+
+    test "it upcases all the strings in {string,string} lists" do
+      headers = [{"a", 1}]
+      new_headers = Utils.convert(headers)
+
+      assert new_headers == [A: 1]
+    end
+  end
 end

--- a/test/api_auth_test.exs
+++ b/test/api_auth_test.exs
@@ -26,6 +26,16 @@ defmodule ApiAuthTest do
       |> assert()
     end
 
+    test "it is true when headers are lowercase and strings (like in Phoenix)" do
+      headers = ApiAuth.headers([], "/", "1044", "123")
+      fun = fn {k, v} -> {String.downcase(Atom.to_string(k)), v} end
+      phoenix_headers = Enum.map(headers, fun)
+
+      phoenix_headers
+      |> ApiAuth.authentic?("/", "1044", "123")
+      |> assert()
+    end
+
     test "it is false when the secret key is different" do
       headers = ApiAuth.headers([], "/", "1044", "123")
 


### PR DESCRIPTION
In Phoenix, headers are lists of `{string,string}` tuples and the keys are all lower case.

To work correctly with Phoenix, convert this to `{atom,string}` and upcase the key string.

Fixes https://github.com/TheGnarCo/api_auth_ex/issues/22
Fixes https://github.com/TheGnarCo/api_auth_ex/issues/23