### PR TITLE
revert ignore params in path commit

### DIFF
--- a/lib/api_auth/uri_header.ex
+++ b/lib/api_auth/uri_header.ex
@@ -20,8 +20,16 @@ defmodule ApiAuth.UriHeader do
   end
 
   def parse_uri(uri) do
-    %{path: path} = URI.parse(uri)
+    %{path: path, query: query} = URI.parse(uri)
 
+    case query do
+      nil -> value_for(path)
+      ""  -> value_for(path)
+      _   -> "#{path}?#{query}"
+    end
+  end
+
+  defp value_for(path) do
     if path && path != "", do: path, else: "/"
   end
 end

--- a/test/api_auth/authorization_header_test.exs
+++ b/test/api_auth/authorization_header_test.exs
@@ -21,6 +21,20 @@ defmodule ApiAuth.AuthorizationHeaderTest do
       assert value == "APIAuth 1044:49FglhLqXWuJqBu5SQOH4F8D1Og="
     end
 
+    test "it calcualtes the signature with query params" do
+      headers = [DATE: "Sat, 01 Jan 2000 00:00:00 GMT", "Content-Type": "application/json"]
+      value = headers
+              |> HeaderValues.wrap()
+              |> DateHeader.headers()
+              |> ContentTypeHeader.headers()
+              |> ContentHashHeader.headers("GET", "", :md5)
+              |> UriHeader.headers("/foo?a=b")
+              |> AuthorizationHeader.override("GET", "1044", "123", :sha)
+              |> HeaderValues.get(:authorization)
+
+      assert value == "APIAuth 1044:EJL51vV1iUgkg6Rxvo7IEXYo4Ys="
+    end
+
     test "it calcualtes the signature with a body" do
       headers = [DATE: "Sat, 01 Jan 2000 00:00:00 GMT", "Content-Type": "text/plain"]
       value = headers
@@ -32,7 +46,7 @@ defmodule ApiAuth.AuthorizationHeaderTest do
               |> AuthorizationHeader.override("PUT", "1044", "123", :sha256)
               |> HeaderValues.get(:authorization)
 
-      assert value == "APIAuth-HMAC-SHA256 1044:bImrylY1pAdLNFl+TpyDMPTcjnFGp1azC1cm86t2rSA="
+      assert value == "APIAuth-HMAC-SHA256 1044:5JhErRhsIbN2+O595t/Rkax2n7w/YZ0f92BYgZFN5ds="
     end
 
     test "it writes the signature to the headers" do

--- a/test/api_auth/uri_header_test.exs
+++ b/test/api_auth/uri_header_test.exs
@@ -44,13 +44,13 @@ defmodule ApiAuth.UriHeaderTest do
       assert value == "/foo"
     end
 
-    test "it removes the get params from the uri" do
+    test "it does not remove the get params from the uri" do
       value = []
               |> HeaderValues.wrap()
               |> UriHeader.headers("/foo?a=b")
               |> HeaderValues.get(:uri)
 
-      assert value == "/foo"
+      assert value == "/foo?a=b"
     end
 
     test "the default uri is /" do


### PR DESCRIPTION
The commit [ignore params in path](https://github.com/TheGnarCo/api_auth_ex/commit/fe828f7fb69df3e3e39aa16f83f7766a5b5194c4) removed URI query params from authorization calculation. This behavior is not compatible with
mgomes api_auth.

This PR restores this with a small refactoring.